### PR TITLE
Enable P2SH addresses to be used with the ElectrumX endpoints

### DIFF
--- a/src/routes/v3/electrumx.js
+++ b/src/routes/v3/electrumx.js
@@ -911,7 +911,9 @@ class Electrum {
       const address = _this.bitcore.Address.fromString(addrStr)
       // console.log(`address: ${address}`)
 
-      const script = _this.bitcore.Script.buildPublicKeyHashOut(address)
+      const script = address.isPayToPublicKeyHash()
+        ? _this.bitcore.Script.buildPublicKeyHashOut(address)
+        : _this.bitcore.Script.buildScriptHashOut(address)
       // console.log(`script: ${script}`)
 
       const scripthash = _this.bitcore.crypto.Hash.sha256(script.toBuffer())

--- a/test/v3/a01-electrumx.js
+++ b/test/v3/a01-electrumx.js
@@ -94,13 +94,24 @@ describe('#ElectrumX Router', () => {
   })
 
   describe('#addressToScripthash', () => {
-    it('should accurately return a scripthash', () => {
+    it('should accurately return a scripthash for a P2PKH address', () => {
       const addr = 'bitcoincash:qpr270a5sxphltdmggtj07v4nskn9gmg9yx4m5h7s4'
 
       const scripthash = electrumxRoute.addressToScripthash(addr)
 
       const expectedOutput =
         'bce4d5f2803bd1ed7c1ba00dcb3edffcbba50524af7c879d6bb918d04f138965'
+
+      assert.equal(scripthash, expectedOutput)
+    })
+
+    it('should accurately return a scripthash for a P2SH address', () => {
+      const addr = 'bitcoincash:pz0z7u9p96h2p6hfychxdrmwgdlzpk5luc5yks2wxq'
+
+      const scripthash = electrumxRoute.addressToScripthash(addr)
+
+      const expectedOutput =
+        '8bc2235c8e7d5634d9ec429fc0171f2c58e728d4f1e2fb7e440e313133cfa4f0'
 
       assert.equal(scripthash, expectedOutput)
     })


### PR DESCRIPTION
- addressToScriptHash() now works correctly with P2SH addresses
- Add single test for this function specifically

I can imagine that you might want to add some additional tests for P2SH addresses here or in the downstream libraries. 