### PR TITLE
Add tx input details to slp/txDetails endpoint

### DIFF
--- a/src/routes/v3/slp.js
+++ b/src/routes/v3/slp.js
@@ -1437,12 +1437,29 @@ class Slp {
       sendOutputs.push(string.toString())
     })
 
+    // Because you are not using insight, you do not get the sending addresses from an indexer
+    // or from the node
+    // However, they are available from the SLPDB output
+    const tokenInputs = transaction.in
+    // Collect the input addresses
+    const sendInputs = []
+    for (let i = 0; i < tokenInputs.length; i += 1) {
+      const tokenInput = tokenInputs[i]
+      const sendInput = {}
+      sendInput.address = tokenInput.e.a
+      sendInputs.push(sendInput)
+    }
+
     const obj = {
       tokenInfo: {
         versionType: transaction.slp.detail.versionType,
+        tokenName: transaction.slp.detail.name,
+        tokenTicker: transaction.slp.detail.symbol,
         transactionType: transaction.slp.detail.transactionType,
         tokenIdHex: transaction.slp.detail.tokenIdHex,
-        sendOutputs: sendOutputs
+        sendOutputs: sendOutputs,
+        sendInputsFull: sendInputs,
+        sendOutputsFull: transaction.slp.detail.outputs,
       },
       tokenIsValid: transaction.slp.valid
     }


### PR DESCRIPTION
The `/slp/txDetails` endpoint does not include parse-able information about the input addresses. This makes it difficult to parse useful information about an SLP transaction, for example which address sent how much SLP to which receiving address.

This info existed in rest.bitcoin.com as it was provided by insight: https://github.com/Bitcoin-com/rest.bitcoin.com/blob/master/src/routes/v3/slp.ts#L2175

This info is available to `bch-api` through the `SLPDB` call. This PR parses the input information in SLPDB to provide input addresses.

`tokenName` and `tokenTicker` are also added.

No information is removed from the existing return object.

The intent here is to provide enough information at one endpoint for a block explorer to usefully describe the SLP transaction. If I have overlooked some easier way of doing this...please let me know ;)