### PR TITLE
URGENT: Remove bignumberjs mod to 8 decimal places

### DIFF
--- a/src/routes/v4/slp.js
+++ b/src/routes/v4/slp.js
@@ -1780,8 +1780,6 @@ class Slp {
 
   // Format the response from SLPDB into an object.
   async formatToRestObject (slpDBFormat) {
-    _this.BigNumber.set({ DECIMAL_PLACES: 8 })
-
     // console.log(`slpDBFormat.data: ${JSON.stringify(slpDBFormat.data, null, 2)}`)
 
     const transaction = slpDBFormat.data.u.length


### PR DESCRIPTION
This line of code was causing all methods on the server that use `BigNumber.js` to round any BigNumbers with more than 8 decimal places to the nearest 8th decimal place, if they were called after this method was called on the server. 

Needs to go. Can create errors in `tokenQty` calculations for `SLP` utxos with 9 decimal places.