### PR TITLE
Changing default tx history behavior (See PR details)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@psf/bch-js": "6.5.3",
+        "@psf/bch-js": "6.5.7",
         "apidoc": "0.53.0",
         "axios": "^0.21.1",
         "bitcore-lib-cash": "^8.23.1",
@@ -935,14 +935,15 @@
       }
     },
     "node_modules/@psf/bch-js": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@psf/bch-js/-/bch-js-6.5.3.tgz",
-      "integrity": "sha512-38UB7NRrVzslZydWZWnB8FVWr5UpxG0cs0Xb1zmovfyOnp96XrAXfWLEuNKstAkpLApegeMY055b7vaKop/wRQ==",
+      "version": "6.5.7",
+      "resolved": "http://94.130.170.209:4873/@psf%2fbch-js/-/bch-js-6.5.7.tgz",
+      "integrity": "sha512-V9UweiRCCU4UzM51Ct2Szhpv6V0B686t5ZjMHNkPu8zyJ9+H7mQfteeQECHK5j38QHvLchfUOif5WWQxP6GRVQ==",
+      "license": "MIT",
       "dependencies": {
         "@chris.troutner/bip32-utils": "1.0.5",
         "@psf/bip21": "2.0.1",
         "@psf/bitcoincash-ops": "2.0.0",
-        "@psf/bitcoincashjs-lib": "4.0.2",
+        "@psf/bitcoincashjs-lib": "4.0.3",
         "@psf/coininfo": "4.0.0",
         "axios": "0.26.1",
         "bc-bip68": "1.0.5",
@@ -999,9 +1000,9 @@
       "license": "MIT"
     },
     "node_modules/@psf/bitcoincashjs-lib": {
-      "version": "4.0.2",
-      "resolved": "http://94.130.170.209:4873/@psf%2fbitcoincashjs-lib/-/bitcoincashjs-lib-4.0.2.tgz",
-      "integrity": "sha512-fTy9mW4H0NkQ+dojGtf+nPduA27F3V2YpBi5licYUVjdVRD/xpUCTgEN1cYRAupOaeDH/AYOWT0MWLkbQSTxAQ==",
+      "version": "4.0.3",
+      "resolved": "http://94.130.170.209:4873/@psf%2fbitcoincashjs-lib/-/bitcoincashjs-lib-4.0.3.tgz",
+      "integrity": "sha512-sJYi7jYUqR7S+Z8TjN3W/5Lcju7xcIBxYLhIEpnOF+jR9kMt0ftpVjQBt8vVsJZUD8ArL9bf59oDETjdOUcdGQ==",
       "license": "MIT",
       "dependencies": {
         "@psf/bitcoincash-ops": "^2.0.0",
@@ -2043,6 +2044,73 @@
         "axios": "0.25.0"
       }
     },
+    "node_modules/bch-consumer/node_modules/@psf/bch-js": {
+      "version": "6.5.3",
+      "resolved": "http://94.130.170.209:4873/@psf%2fbch-js/-/bch-js-6.5.3.tgz",
+      "integrity": "sha512-38UB7NRrVzslZydWZWnB8FVWr5UpxG0cs0Xb1zmovfyOnp96XrAXfWLEuNKstAkpLApegeMY055b7vaKop/wRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chris.troutner/bip32-utils": "1.0.5",
+        "@psf/bip21": "2.0.1",
+        "@psf/bitcoincash-ops": "2.0.0",
+        "@psf/bitcoincashjs-lib": "4.0.2",
+        "@psf/coininfo": "4.0.0",
+        "axios": "0.26.1",
+        "bc-bip68": "1.0.5",
+        "bchaddrjs-slp": "0.2.5",
+        "bigi": "1.4.2",
+        "bignumber.js": "9.0.0",
+        "bip-schnorr": "0.3.0",
+        "bip38": "2.0.2",
+        "bip39": "3.0.2",
+        "bip66": "1.1.5",
+        "bitcoinjs-message": "2.0.0",
+        "bs58": "4.0.1",
+        "ecashaddrjs": "1.0.7",
+        "ini": "1.3.8",
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.2",
+        "satoshi-bitcoin": "1.0.4",
+        "slp-mdm": "0.0.6",
+        "slp-parser": "0.0.4",
+        "wif": "2.0.6"
+      }
+    },
+    "node_modules/bch-consumer/node_modules/@psf/bch-js/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "http://94.130.170.209:4873/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/bch-consumer/node_modules/@psf/bitcoincashjs-lib": {
+      "version": "4.0.2",
+      "resolved": "http://94.130.170.209:4873/@psf%2fbitcoincashjs-lib/-/bitcoincashjs-lib-4.0.2.tgz",
+      "integrity": "sha512-fTy9mW4H0NkQ+dojGtf+nPduA27F3V2YpBi5licYUVjdVRD/xpUCTgEN1cYRAupOaeDH/AYOWT0MWLkbQSTxAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@psf/bitcoincash-ops": "^2.0.0",
+        "@psf/pushdata-bitcoin": "^1.2.2",
+        "bech32": "^1.1.2",
+        "bigi": "^1.4.0",
+        "bip66": "^1.1.0",
+        "bs58check": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.3",
+        "ecurve": "^1.0.0",
+        "merkle-lib": "^2.0.10",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "typeforce": "^1.18.0",
+        "varuint-bitcoin": "^1.0.4",
+        "wif": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.15.1"
+      }
+    },
     "node_modules/bch-consumer/node_modules/apidoc": {
       "version": "0.51.0",
       "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-0.51.0.tgz",
@@ -2091,6 +2159,15 @@
       "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "dependencies": {
         "follow-redirects": "^1.14.7"
+      }
+    },
+    "node_modules/bch-consumer/node_modules/bignumber.js": {
+      "version": "9.0.0",
+      "resolved": "http://94.130.170.209:4873/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/bch-consumer/node_modules/fs-extra": {
@@ -8625,6 +8702,64 @@
         "xec-consumer": "1.0.1"
       }
     },
+    "node_modules/minimal-ecash-wallet/node_modules/@psf/bch-js": {
+      "version": "6.5.3",
+      "resolved": "http://94.130.170.209:4873/@psf%2fbch-js/-/bch-js-6.5.3.tgz",
+      "integrity": "sha512-38UB7NRrVzslZydWZWnB8FVWr5UpxG0cs0Xb1zmovfyOnp96XrAXfWLEuNKstAkpLApegeMY055b7vaKop/wRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chris.troutner/bip32-utils": "1.0.5",
+        "@psf/bip21": "2.0.1",
+        "@psf/bitcoincash-ops": "2.0.0",
+        "@psf/bitcoincashjs-lib": "4.0.2",
+        "@psf/coininfo": "4.0.0",
+        "axios": "0.26.1",
+        "bc-bip68": "1.0.5",
+        "bchaddrjs-slp": "0.2.5",
+        "bigi": "1.4.2",
+        "bignumber.js": "9.0.0",
+        "bip-schnorr": "0.3.0",
+        "bip38": "2.0.2",
+        "bip39": "3.0.2",
+        "bip66": "1.1.5",
+        "bitcoinjs-message": "2.0.0",
+        "bs58": "4.0.1",
+        "ecashaddrjs": "1.0.7",
+        "ini": "1.3.8",
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.2",
+        "satoshi-bitcoin": "1.0.4",
+        "slp-mdm": "0.0.6",
+        "slp-parser": "0.0.4",
+        "wif": "2.0.6"
+      }
+    },
+    "node_modules/minimal-ecash-wallet/node_modules/@psf/bitcoincashjs-lib": {
+      "version": "4.0.2",
+      "resolved": "http://94.130.170.209:4873/@psf%2fbitcoincashjs-lib/-/bitcoincashjs-lib-4.0.2.tgz",
+      "integrity": "sha512-fTy9mW4H0NkQ+dojGtf+nPduA27F3V2YpBi5licYUVjdVRD/xpUCTgEN1cYRAupOaeDH/AYOWT0MWLkbQSTxAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@psf/bitcoincash-ops": "^2.0.0",
+        "@psf/pushdata-bitcoin": "^1.2.2",
+        "bech32": "^1.1.2",
+        "bigi": "^1.4.0",
+        "bip66": "^1.1.0",
+        "bs58check": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.3",
+        "ecurve": "^1.0.0",
+        "merkle-lib": "^2.0.10",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "typeforce": "^1.18.0",
+        "varuint-bitcoin": "^1.0.4",
+        "wif": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.15.1"
+      }
+    },
     "node_modules/minimal-ecash-wallet/node_modules/apidoc": {
       "version": "0.51.0",
       "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-0.51.0.tgz",
@@ -8667,6 +8802,24 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/minimal-ecash-wallet/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "http://94.130.170.209:4873/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/minimal-ecash-wallet/node_modules/bignumber.js": {
+      "version": "9.0.0",
+      "resolved": "http://94.130.170.209:4873/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/minimal-ecash-wallet/node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -8696,6 +8849,64 @@
         "bch-consumer": "1.4.1",
         "bch-donation": "1.1.2",
         "crypto-js": "4.0.0"
+      }
+    },
+    "node_modules/minimal-slp-wallet/node_modules/@psf/bch-js": {
+      "version": "6.5.3",
+      "resolved": "http://94.130.170.209:4873/@psf%2fbch-js/-/bch-js-6.5.3.tgz",
+      "integrity": "sha512-38UB7NRrVzslZydWZWnB8FVWr5UpxG0cs0Xb1zmovfyOnp96XrAXfWLEuNKstAkpLApegeMY055b7vaKop/wRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chris.troutner/bip32-utils": "1.0.5",
+        "@psf/bip21": "2.0.1",
+        "@psf/bitcoincash-ops": "2.0.0",
+        "@psf/bitcoincashjs-lib": "4.0.2",
+        "@psf/coininfo": "4.0.0",
+        "axios": "0.26.1",
+        "bc-bip68": "1.0.5",
+        "bchaddrjs-slp": "0.2.5",
+        "bigi": "1.4.2",
+        "bignumber.js": "9.0.0",
+        "bip-schnorr": "0.3.0",
+        "bip38": "2.0.2",
+        "bip39": "3.0.2",
+        "bip66": "1.1.5",
+        "bitcoinjs-message": "2.0.0",
+        "bs58": "4.0.1",
+        "ecashaddrjs": "1.0.7",
+        "ini": "1.3.8",
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.2",
+        "satoshi-bitcoin": "1.0.4",
+        "slp-mdm": "0.0.6",
+        "slp-parser": "0.0.4",
+        "wif": "2.0.6"
+      }
+    },
+    "node_modules/minimal-slp-wallet/node_modules/@psf/bitcoincashjs-lib": {
+      "version": "4.0.2",
+      "resolved": "http://94.130.170.209:4873/@psf%2fbitcoincashjs-lib/-/bitcoincashjs-lib-4.0.2.tgz",
+      "integrity": "sha512-fTy9mW4H0NkQ+dojGtf+nPduA27F3V2YpBi5licYUVjdVRD/xpUCTgEN1cYRAupOaeDH/AYOWT0MWLkbQSTxAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@psf/bitcoincash-ops": "^2.0.0",
+        "@psf/pushdata-bitcoin": "^1.2.2",
+        "bech32": "^1.1.2",
+        "bigi": "^1.4.0",
+        "bip66": "^1.1.0",
+        "bs58check": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.3",
+        "ecurve": "^1.0.0",
+        "merkle-lib": "^2.0.10",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "typeforce": "^1.18.0",
+        "varuint-bitcoin": "^1.0.4",
+        "wif": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.15.1"
       }
     },
     "node_modules/minimal-slp-wallet/node_modules/apidoc": {
@@ -8738,6 +8949,24 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/minimal-slp-wallet/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "http://94.130.170.209:4873/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/minimal-slp-wallet/node_modules/bignumber.js": {
+      "version": "9.0.0",
+      "resolved": "http://94.130.170.209:4873/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/minimal-slp-wallet/node_modules/fs-extra": {
@@ -17001,6 +17230,73 @@
         "axios": "0.25.0"
       }
     },
+    "node_modules/xec-consumer/node_modules/@psf/bch-js": {
+      "version": "6.5.3",
+      "resolved": "http://94.130.170.209:4873/@psf%2fbch-js/-/bch-js-6.5.3.tgz",
+      "integrity": "sha512-38UB7NRrVzslZydWZWnB8FVWr5UpxG0cs0Xb1zmovfyOnp96XrAXfWLEuNKstAkpLApegeMY055b7vaKop/wRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chris.troutner/bip32-utils": "1.0.5",
+        "@psf/bip21": "2.0.1",
+        "@psf/bitcoincash-ops": "2.0.0",
+        "@psf/bitcoincashjs-lib": "4.0.2",
+        "@psf/coininfo": "4.0.0",
+        "axios": "0.26.1",
+        "bc-bip68": "1.0.5",
+        "bchaddrjs-slp": "0.2.5",
+        "bigi": "1.4.2",
+        "bignumber.js": "9.0.0",
+        "bip-schnorr": "0.3.0",
+        "bip38": "2.0.2",
+        "bip39": "3.0.2",
+        "bip66": "1.1.5",
+        "bitcoinjs-message": "2.0.0",
+        "bs58": "4.0.1",
+        "ecashaddrjs": "1.0.7",
+        "ini": "1.3.8",
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.2",
+        "satoshi-bitcoin": "1.0.4",
+        "slp-mdm": "0.0.6",
+        "slp-parser": "0.0.4",
+        "wif": "2.0.6"
+      }
+    },
+    "node_modules/xec-consumer/node_modules/@psf/bch-js/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "http://94.130.170.209:4873/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/xec-consumer/node_modules/@psf/bitcoincashjs-lib": {
+      "version": "4.0.2",
+      "resolved": "http://94.130.170.209:4873/@psf%2fbitcoincashjs-lib/-/bitcoincashjs-lib-4.0.2.tgz",
+      "integrity": "sha512-fTy9mW4H0NkQ+dojGtf+nPduA27F3V2YpBi5licYUVjdVRD/xpUCTgEN1cYRAupOaeDH/AYOWT0MWLkbQSTxAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@psf/bitcoincash-ops": "^2.0.0",
+        "@psf/pushdata-bitcoin": "^1.2.2",
+        "bech32": "^1.1.2",
+        "bigi": "^1.4.0",
+        "bip66": "^1.1.0",
+        "bs58check": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.3",
+        "ecurve": "^1.0.0",
+        "merkle-lib": "^2.0.10",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "typeforce": "^1.18.0",
+        "varuint-bitcoin": "^1.0.4",
+        "wif": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.15.1"
+      }
+    },
     "node_modules/xec-consumer/node_modules/apidoc": {
       "version": "0.51.0",
       "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-0.51.0.tgz",
@@ -17049,6 +17345,15 @@
       "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "dependencies": {
         "follow-redirects": "^1.14.7"
+      }
+    },
+    "node_modules/xec-consumer/node_modules/bignumber.js": {
+      "version": "9.0.0",
+      "resolved": "http://94.130.170.209:4873/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/xec-consumer/node_modules/fs-extra": {
@@ -17899,14 +18204,14 @@
       }
     },
     "@psf/bch-js": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@psf/bch-js/-/bch-js-6.5.3.tgz",
-      "integrity": "sha512-38UB7NRrVzslZydWZWnB8FVWr5UpxG0cs0Xb1zmovfyOnp96XrAXfWLEuNKstAkpLApegeMY055b7vaKop/wRQ==",
+      "version": "6.5.7",
+      "resolved": "http://94.130.170.209:4873/@psf%2fbch-js/-/bch-js-6.5.7.tgz",
+      "integrity": "sha512-V9UweiRCCU4UzM51Ct2Szhpv6V0B686t5ZjMHNkPu8zyJ9+H7mQfteeQECHK5j38QHvLchfUOif5WWQxP6GRVQ==",
       "requires": {
         "@chris.troutner/bip32-utils": "1.0.5",
         "@psf/bip21": "2.0.1",
         "@psf/bitcoincash-ops": "2.0.0",
-        "@psf/bitcoincashjs-lib": "4.0.2",
+        "@psf/bitcoincashjs-lib": "4.0.3",
         "@psf/coininfo": "4.0.0",
         "axios": "0.26.1",
         "bc-bip68": "1.0.5",
@@ -17958,9 +18263,9 @@
       "integrity": "sha512-M3PWqRpeJq6rli2NqWGbas76z9TrdGOmNuDFACBWBMctPucEAsFQY2AmyFHRSa7hEwythwvrPh9AG/n6ehmEog=="
     },
     "@psf/bitcoincashjs-lib": {
-      "version": "4.0.2",
-      "resolved": "http://94.130.170.209:4873/@psf%2fbitcoincashjs-lib/-/bitcoincashjs-lib-4.0.2.tgz",
-      "integrity": "sha512-fTy9mW4H0NkQ+dojGtf+nPduA27F3V2YpBi5licYUVjdVRD/xpUCTgEN1cYRAupOaeDH/AYOWT0MWLkbQSTxAQ==",
+      "version": "4.0.3",
+      "resolved": "http://94.130.170.209:4873/@psf%2fbitcoincashjs-lib/-/bitcoincashjs-lib-4.0.3.tgz",
+      "integrity": "sha512-sJYi7jYUqR7S+Z8TjN3W/5Lcju7xcIBxYLhIEpnOF+jR9kMt0ftpVjQBt8vVsJZUD8ArL9bf59oDETjdOUcdGQ==",
       "requires": {
         "@psf/bitcoincash-ops": "^2.0.0",
         "@psf/pushdata-bitcoin": "^1.2.2",
@@ -18755,6 +19060,69 @@
         "axios": "0.25.0"
       },
       "dependencies": {
+        "@psf/bch-js": {
+          "version": "6.5.3",
+          "resolved": "http://94.130.170.209:4873/@psf%2fbch-js/-/bch-js-6.5.3.tgz",
+          "integrity": "sha512-38UB7NRrVzslZydWZWnB8FVWr5UpxG0cs0Xb1zmovfyOnp96XrAXfWLEuNKstAkpLApegeMY055b7vaKop/wRQ==",
+          "requires": {
+            "@chris.troutner/bip32-utils": "1.0.5",
+            "@psf/bip21": "2.0.1",
+            "@psf/bitcoincash-ops": "2.0.0",
+            "@psf/bitcoincashjs-lib": "4.0.2",
+            "@psf/coininfo": "4.0.0",
+            "axios": "0.26.1",
+            "bc-bip68": "1.0.5",
+            "bchaddrjs-slp": "0.2.5",
+            "bigi": "1.4.2",
+            "bignumber.js": "9.0.0",
+            "bip-schnorr": "0.3.0",
+            "bip38": "2.0.2",
+            "bip39": "3.0.2",
+            "bip66": "1.1.5",
+            "bitcoinjs-message": "2.0.0",
+            "bs58": "4.0.1",
+            "ecashaddrjs": "1.0.7",
+            "ini": "1.3.8",
+            "randombytes": "2.0.6",
+            "safe-buffer": "5.1.2",
+            "satoshi-bitcoin": "1.0.4",
+            "slp-mdm": "0.0.6",
+            "slp-parser": "0.0.4",
+            "wif": "2.0.6"
+          },
+          "dependencies": {
+            "axios": {
+              "version": "0.26.1",
+              "resolved": "http://94.130.170.209:4873/axios/-/axios-0.26.1.tgz",
+              "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+              "requires": {
+                "follow-redirects": "^1.14.8"
+              }
+            }
+          }
+        },
+        "@psf/bitcoincashjs-lib": {
+          "version": "4.0.2",
+          "resolved": "http://94.130.170.209:4873/@psf%2fbitcoincashjs-lib/-/bitcoincashjs-lib-4.0.2.tgz",
+          "integrity": "sha512-fTy9mW4H0NkQ+dojGtf+nPduA27F3V2YpBi5licYUVjdVRD/xpUCTgEN1cYRAupOaeDH/AYOWT0MWLkbQSTxAQ==",
+          "requires": {
+            "@psf/bitcoincash-ops": "^2.0.0",
+            "@psf/pushdata-bitcoin": "^1.2.2",
+            "bech32": "^1.1.2",
+            "bigi": "^1.4.0",
+            "bip66": "^1.1.0",
+            "bs58check": "^2.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.3",
+            "ecurve": "^1.0.0",
+            "merkle-lib": "^2.0.10",
+            "randombytes": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "typeforce": "^1.18.0",
+            "varuint-bitcoin": "^1.0.4",
+            "wif": "^2.0.1"
+          }
+        },
         "apidoc": {
           "version": "0.51.0",
           "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-0.51.0.tgz",
@@ -18791,6 +19159,11 @@
           "requires": {
             "follow-redirects": "^1.14.7"
           }
+        },
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "http://94.130.170.209:4873/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
         },
         "fs-extra": {
           "version": "10.1.0",
@@ -23323,6 +23696,59 @@
         "xec-consumer": "1.0.1"
       },
       "dependencies": {
+        "@psf/bch-js": {
+          "version": "6.5.3",
+          "resolved": "http://94.130.170.209:4873/@psf%2fbch-js/-/bch-js-6.5.3.tgz",
+          "integrity": "sha512-38UB7NRrVzslZydWZWnB8FVWr5UpxG0cs0Xb1zmovfyOnp96XrAXfWLEuNKstAkpLApegeMY055b7vaKop/wRQ==",
+          "requires": {
+            "@chris.troutner/bip32-utils": "1.0.5",
+            "@psf/bip21": "2.0.1",
+            "@psf/bitcoincash-ops": "2.0.0",
+            "@psf/bitcoincashjs-lib": "4.0.2",
+            "@psf/coininfo": "4.0.0",
+            "axios": "0.26.1",
+            "bc-bip68": "1.0.5",
+            "bchaddrjs-slp": "0.2.5",
+            "bigi": "1.4.2",
+            "bignumber.js": "9.0.0",
+            "bip-schnorr": "0.3.0",
+            "bip38": "2.0.2",
+            "bip39": "3.0.2",
+            "bip66": "1.1.5",
+            "bitcoinjs-message": "2.0.0",
+            "bs58": "4.0.1",
+            "ecashaddrjs": "1.0.7",
+            "ini": "1.3.8",
+            "randombytes": "2.0.6",
+            "safe-buffer": "5.1.2",
+            "satoshi-bitcoin": "1.0.4",
+            "slp-mdm": "0.0.6",
+            "slp-parser": "0.0.4",
+            "wif": "2.0.6"
+          }
+        },
+        "@psf/bitcoincashjs-lib": {
+          "version": "4.0.2",
+          "resolved": "http://94.130.170.209:4873/@psf%2fbitcoincashjs-lib/-/bitcoincashjs-lib-4.0.2.tgz",
+          "integrity": "sha512-fTy9mW4H0NkQ+dojGtf+nPduA27F3V2YpBi5licYUVjdVRD/xpUCTgEN1cYRAupOaeDH/AYOWT0MWLkbQSTxAQ==",
+          "requires": {
+            "@psf/bitcoincash-ops": "^2.0.0",
+            "@psf/pushdata-bitcoin": "^1.2.2",
+            "bech32": "^1.1.2",
+            "bigi": "^1.4.0",
+            "bip66": "^1.1.0",
+            "bs58check": "^2.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.3",
+            "ecurve": "^1.0.0",
+            "merkle-lib": "^2.0.10",
+            "randombytes": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "typeforce": "^1.18.0",
+            "varuint-bitcoin": "^1.0.4",
+            "wif": "^2.0.1"
+          }
+        },
         "apidoc": {
           "version": "0.51.0",
           "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-0.51.0.tgz",
@@ -23351,6 +23777,19 @@
             "webpack-cli": "^4.9.1",
             "winston": "^3.3.3"
           }
+        },
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "http://94.130.170.209:4873/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "http://94.130.170.209:4873/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
         },
         "fs-extra": {
           "version": "10.1.0",
@@ -23382,6 +23821,59 @@
         "crypto-js": "4.0.0"
       },
       "dependencies": {
+        "@psf/bch-js": {
+          "version": "6.5.3",
+          "resolved": "http://94.130.170.209:4873/@psf%2fbch-js/-/bch-js-6.5.3.tgz",
+          "integrity": "sha512-38UB7NRrVzslZydWZWnB8FVWr5UpxG0cs0Xb1zmovfyOnp96XrAXfWLEuNKstAkpLApegeMY055b7vaKop/wRQ==",
+          "requires": {
+            "@chris.troutner/bip32-utils": "1.0.5",
+            "@psf/bip21": "2.0.1",
+            "@psf/bitcoincash-ops": "2.0.0",
+            "@psf/bitcoincashjs-lib": "4.0.2",
+            "@psf/coininfo": "4.0.0",
+            "axios": "0.26.1",
+            "bc-bip68": "1.0.5",
+            "bchaddrjs-slp": "0.2.5",
+            "bigi": "1.4.2",
+            "bignumber.js": "9.0.0",
+            "bip-schnorr": "0.3.0",
+            "bip38": "2.0.2",
+            "bip39": "3.0.2",
+            "bip66": "1.1.5",
+            "bitcoinjs-message": "2.0.0",
+            "bs58": "4.0.1",
+            "ecashaddrjs": "1.0.7",
+            "ini": "1.3.8",
+            "randombytes": "2.0.6",
+            "safe-buffer": "5.1.2",
+            "satoshi-bitcoin": "1.0.4",
+            "slp-mdm": "0.0.6",
+            "slp-parser": "0.0.4",
+            "wif": "2.0.6"
+          }
+        },
+        "@psf/bitcoincashjs-lib": {
+          "version": "4.0.2",
+          "resolved": "http://94.130.170.209:4873/@psf%2fbitcoincashjs-lib/-/bitcoincashjs-lib-4.0.2.tgz",
+          "integrity": "sha512-fTy9mW4H0NkQ+dojGtf+nPduA27F3V2YpBi5licYUVjdVRD/xpUCTgEN1cYRAupOaeDH/AYOWT0MWLkbQSTxAQ==",
+          "requires": {
+            "@psf/bitcoincash-ops": "^2.0.0",
+            "@psf/pushdata-bitcoin": "^1.2.2",
+            "bech32": "^1.1.2",
+            "bigi": "^1.4.0",
+            "bip66": "^1.1.0",
+            "bs58check": "^2.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.3",
+            "ecurve": "^1.0.0",
+            "merkle-lib": "^2.0.10",
+            "randombytes": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "typeforce": "^1.18.0",
+            "varuint-bitcoin": "^1.0.4",
+            "wif": "^2.0.1"
+          }
+        },
         "apidoc": {
           "version": "0.51.0",
           "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-0.51.0.tgz",
@@ -23410,6 +23902,19 @@
             "webpack-cli": "^4.9.1",
             "winston": "^3.3.3"
           }
+        },
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "http://94.130.170.209:4873/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "http://94.130.170.209:4873/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
         },
         "fs-extra": {
           "version": "10.1.0",
@@ -29267,6 +29772,69 @@
         "axios": "0.25.0"
       },
       "dependencies": {
+        "@psf/bch-js": {
+          "version": "6.5.3",
+          "resolved": "http://94.130.170.209:4873/@psf%2fbch-js/-/bch-js-6.5.3.tgz",
+          "integrity": "sha512-38UB7NRrVzslZydWZWnB8FVWr5UpxG0cs0Xb1zmovfyOnp96XrAXfWLEuNKstAkpLApegeMY055b7vaKop/wRQ==",
+          "requires": {
+            "@chris.troutner/bip32-utils": "1.0.5",
+            "@psf/bip21": "2.0.1",
+            "@psf/bitcoincash-ops": "2.0.0",
+            "@psf/bitcoincashjs-lib": "4.0.2",
+            "@psf/coininfo": "4.0.0",
+            "axios": "0.26.1",
+            "bc-bip68": "1.0.5",
+            "bchaddrjs-slp": "0.2.5",
+            "bigi": "1.4.2",
+            "bignumber.js": "9.0.0",
+            "bip-schnorr": "0.3.0",
+            "bip38": "2.0.2",
+            "bip39": "3.0.2",
+            "bip66": "1.1.5",
+            "bitcoinjs-message": "2.0.0",
+            "bs58": "4.0.1",
+            "ecashaddrjs": "1.0.7",
+            "ini": "1.3.8",
+            "randombytes": "2.0.6",
+            "safe-buffer": "5.1.2",
+            "satoshi-bitcoin": "1.0.4",
+            "slp-mdm": "0.0.6",
+            "slp-parser": "0.0.4",
+            "wif": "2.0.6"
+          },
+          "dependencies": {
+            "axios": {
+              "version": "0.26.1",
+              "resolved": "http://94.130.170.209:4873/axios/-/axios-0.26.1.tgz",
+              "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+              "requires": {
+                "follow-redirects": "^1.14.8"
+              }
+            }
+          }
+        },
+        "@psf/bitcoincashjs-lib": {
+          "version": "4.0.2",
+          "resolved": "http://94.130.170.209:4873/@psf%2fbitcoincashjs-lib/-/bitcoincashjs-lib-4.0.2.tgz",
+          "integrity": "sha512-fTy9mW4H0NkQ+dojGtf+nPduA27F3V2YpBi5licYUVjdVRD/xpUCTgEN1cYRAupOaeDH/AYOWT0MWLkbQSTxAQ==",
+          "requires": {
+            "@psf/bitcoincash-ops": "^2.0.0",
+            "@psf/pushdata-bitcoin": "^1.2.2",
+            "bech32": "^1.1.2",
+            "bigi": "^1.4.0",
+            "bip66": "^1.1.0",
+            "bs58check": "^2.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.3",
+            "ecurve": "^1.0.0",
+            "merkle-lib": "^2.0.10",
+            "randombytes": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "typeforce": "^1.18.0",
+            "varuint-bitcoin": "^1.0.4",
+            "wif": "^2.0.1"
+          }
+        },
         "apidoc": {
           "version": "0.51.0",
           "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-0.51.0.tgz",
@@ -29303,6 +29871,11 @@
           "requires": {
             "follow-redirects": "^1.14.7"
           }
+        },
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "http://94.130.170.209:4873/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
         },
         "fs-extra": {
           "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node": ">=10.15.1"
   },
   "dependencies": {
-    "@psf/bch-js": "6.5.3",
+    "@psf/bch-js": "6.5.7",
     "apidoc": "0.53.0",
     "axios": "^0.21.1",
     "bitcore-lib-cash": "^8.23.1",

--- a/src/util/route-utils.js
+++ b/src/util/route-utils.js
@@ -63,12 +63,15 @@ class RouteUtils {
   // trest.bitcoin.com.
   validateNetwork (addr) {
     try {
-      const network = process.env.NETWORK
+      let network = process.env.NETWORK
 
       // Return false if NETWORK is not defined.
       if (!network || network === '') {
-        console.log('Warning: NETWORK environment variable is not defined!')
-        return false
+        // console.log('Warning: NETWORK environment variable is not defined!')
+        // return false
+
+        // Default to mainnet
+        network = 'mainnet'
       }
 
       // Convert the user-provided address to a cashaddress, for easy detection

--- a/test-local-bchn.sh
+++ b/test-local-bchn.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Connect to cloud infrastructure and run integration tests.
+
+export NETWORK=mainnet
+
+# mainnet full node
+export RPC_IP=172.17.0.1:8332
+export RPC_BASEURL=http://$RPC_IP/
+export RPC_USERNAME=bitcoin
+export RPC_PASSWORD=password
+
+# Mainnet Fulcrum / ElectrumX
+export FULCRUM_API=http://172.17.0.1:3001/v1/
+
+# psf-slp-indxer
+export SLP_INDEXER_API=http://172.17.0.1:5021/
+
+# Redis DB - Used for rate limiting - customize to your own Redis installation.
+export REDIS_PORT=6379
+#export REDIS_HOST=172.17.0.1
+export REDIS_HOST=127.0.0.1
+
+# JWT Token Secret
+# This is used to verify JWT tokens generated with jwt-bch-api:
+# https://github.com/Permissionless-Software-Foundation/jwt-bch-api
+export TOKENSECRET=somelongpassword
+
+# So that bch-api can call bch-js locally.
+#export LOCAL_RESTURL=http://127.0.0.1:3000/v5/
+export LOCAL_RESTURL=https://bchn.fullstack.cash/v5/
+
+# Basic Authentication password
+export PRO_PASS=somerandomepassword:someotherrandompassword:aThirdPassword
+
+# Uncomment the line below if you do not want to use rate limits
+export DO_NOT_USE_RATE_LIMITS=1
+
+export TEST=integration
+
+export ISBCHN=true
+
+npm run test
+
+# mocha --timeout 15000 -g '#getBlock()' --exit test/v4/
+
+#export NETWORK=mainnet
+#mocha --timeout 25000 test/v3/electrumx.js

--- a/test/v5/a01-electrumx.js
+++ b/test/v5/a01-electrumx.js
@@ -1360,6 +1360,7 @@ describe('#Electrumx', () => {
       assert.property(result.transactions[0], 'tx_hash')
     })
   })
+
   describe('#transactionsBulk', () => {
     it('should throw 400 if addresses is empty', async () => {
       const result = await electrumxRoute.transactionsBulk(req, res)
@@ -1453,6 +1454,7 @@ describe('#Electrumx', () => {
       assert.property(result, 'error')
       assert.include(result.error, 'Invalid BCH address')
     })
+
     it('should handle error', async () => {
       req.body.addresses = [
         'bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7',
@@ -1471,6 +1473,7 @@ describe('#Electrumx', () => {
       assert.property(result, 'error')
       assert.include(result.error, 'Test error')
     })
+
     it('should get transaction for an array of addresses', async () => {
       req.body.addresses = [
         'bitcoincash:qp3sn6vlwz28ntmf3wmyra7jqttfx7z6zgtkygjhc7',
@@ -1503,6 +1506,7 @@ describe('#Electrumx', () => {
       assert.property(result.transactions[0].transactions[0], 'tx_hash')
     })
   })
+
   describe('#getMempool', () => {
     it('should throw 400 if address is empty', async () => {
       const result = await electrumxRoute.getMempool(req, res)

--- a/test/v5/integration/electrumx.js
+++ b/test/v5/integration/electrumx.js
@@ -1,0 +1,72 @@
+/*
+  Integration tests for the electrumx.js library.
+*/
+
+// Global npm libraries
+const assert = require('chai').assert
+
+// Local libraries
+const { mockReq, mockRes } = require('../mocks/express-mocks')
+const Electrum = require('../../../src/routes/v5/electrumx')
+
+describe('#electrumx', () => {
+  let req, res
+  let uut // Unit under test
+
+  before(() => {
+    if (!process.env.FULCRUM_API) {
+      process.env.FULCRUM_API = 'http://localhost:3001/v1/'
+    }
+
+    uut = new Electrum()
+  })
+
+  beforeEach(() => {
+    // Mock the req and res objects used by Express routes.
+    req = mockReq
+    res = mockRes
+  })
+
+  describe('#transactionsBulk', () => {
+    it('should return only last 100 tx in history', async () => {
+      const testAddr = 'bitcoincash:qqlrzp23w08434twmvr4fxw672whkjy0py26r63g3d'
+      req.body.addresses = [testAddr]
+
+      const result = await uut.transactionsBulk(req, res)
+      // console.log('result: ', JSON.stringify(result, null, 2))
+
+      // Assert that the returned address is the one expected.
+      assert.equal(result.transactions[0].address, testAddr)
+
+      // Assert that the number of transaction are only 100, and not the
+      // complete transaction history.
+      assert.equal(result.transactions[0].transactions.length, 100)
+
+      // Assert that the first element is larger than the last element
+      const firstElem = result.transactions[0].transactions[0]
+      const lastElem = result.transactions[0].transactions.slice(-1)
+      assert.isAbove(firstElem.height, lastElem[0].height)
+    })
+
+    it('should return the entire tx history', async () => {
+      const testAddr = 'bitcoincash:qqlrzp23w08434twmvr4fxw672whkjy0py26r63g3d'
+      req.body.addresses = [testAddr]
+      req.body.allTxs = true
+
+      const result = await uut.transactionsBulk(req, res)
+      // console.log('result: ', JSON.stringify(result, null, 2))
+
+      // Assert that the returned address is the one expected.
+      assert.equal(result.transactions[0].address, testAddr)
+
+      // Assert that the number of transaction are only 100, and not the
+      // complete transaction history.
+      assert.isAbove(result.transactions[0].transactions.length, 100)
+
+      // Assert that the first element is larger than the last element
+      const firstElem = result.transactions[0].transactions[0]
+      const lastElem = result.transactions[0].transactions.slice(-1)
+      assert.isAbove(firstElem.height, lastElem[0].height)
+    })
+  })
+})

--- a/test/v5/integration/electrumx.js
+++ b/test/v5/integration/electrumx.js
@@ -69,4 +69,42 @@ describe('#electrumx', () => {
       assert.isAbove(firstElem.height, lastElem[0].height)
     })
   })
+
+  describe('#getTransactions', () => {
+    it('should return only last 100 tx in history', async () => {
+      const testAddr = 'bitcoincash:qqlrzp23w08434twmvr4fxw672whkjy0py26r63g3d'
+      req.params.address = testAddr
+      req.params.allTxs = false
+
+      const result = await uut.getTransactions(req, res)
+      // console.log('result: ', JSON.stringify(result, null, 2))
+
+      // Assert that the number of transaction are only 100, and not the
+      // complete transaction history.
+      assert.equal(result.transactions.length, 100)
+
+      // Assert that the first element is larger than the last element
+      const firstElem = result.transactions[0]
+      const lastElem = result.transactions.slice(-1)
+      assert.isAbove(firstElem.height, lastElem[0].height)
+    })
+
+    it('should return the entire tx history', async () => {
+      const testAddr = 'bitcoincash:qqlrzp23w08434twmvr4fxw672whkjy0py26r63g3d'
+      req.params.address = testAddr
+      req.params.allTxs = true
+
+      const result = await uut.getTransactions(req, res)
+      // console.log('result: ', JSON.stringify(result, null, 2))
+
+      // Assert that the number of transaction are only 100, and not the
+      // complete transaction history.
+      assert.isAbove(result.transactions.length, 100)
+
+      // Assert that the first element is larger than the last element
+      const firstElem = result.transactions[0]
+      const lastElem = result.transactions.slice(-1)
+      assert.isAbove(firstElem.height, lastElem[0].height)
+    })
+  })
 })

--- a/test/v5/integration/nft.js
+++ b/test/v5/integration/nft.js
@@ -5,6 +5,7 @@
 
 'use strict'
 
+// Global npm libraries
 const chai = require('chai')
 const assert = chai.assert
 // const axios = require('axios')
@@ -47,6 +48,7 @@ describe('#nft', () => {
         'Error message expected'
       )
     })
+
     it('should return error on non-group NFT token', async () => {
       req.params.tokenId =
         '45a30085691d6ea586e3ec2aa9122e9b0e0d6c3c1fd357decccc15d8efde48a9'

--- a/test/v5/raw-transactions.js
+++ b/test/v5/raw-transactions.js
@@ -442,9 +442,11 @@ describe('#Raw-Transactions', () => {
         '0200000001b9b598d7d6d72fc486b2b3a3c03c79b5bade6ec9a77ced850515ab5e64edcc21010000006b483045022100a7b1b08956abb8d6f322aa709d8583c8ea492ba0585f1a6f4f9983520af74a5a0220411aee4a9a54effab617b0508c504c31681b15f9b187179b4874257badd4139041210360cfc66fdacb650bc4c83b4e351805181ee696b7d5ab4667c57b2786f51c413dffffffff0210270000000000001976a914eb4b180def88e3f5625b2d8ae2c098ff7d85f66488ac786e9800000000001976a914eb4b180def88e3f5625b2d8ae2c098ff7d85f66488ac00000000'
 
       const result = await uut.decodeScriptSingle(req, res)
-      // console.log(`result: ${util.inspect(result)}`)
+      console.log(`result: ${util.inspect(result)}`)
 
-      assert.hasAllKeys(result, ['asm', 'type', 'p2sh'])
+      assert.property(result, 'asm')
+      assert.property(result, 'type')
+      assert.property(result, 'p2sh')
     })
   })
 
@@ -563,7 +565,9 @@ describe('#Raw-Transactions', () => {
       // console.log(`result: ${util.inspect(result)}`)
 
       assert.isArray(result)
-      assert.hasAllKeys(result[0], ['asm', 'type', 'p2sh'])
+      assert.property(result[0], 'asm')
+      assert.property(result[0], 'type')
+      assert.property(result[0], 'p2sh')
     })
 
     it('should decode an array with a multiple hexes', async () => {
@@ -584,7 +588,9 @@ describe('#Raw-Transactions', () => {
 
       assert.isArray(result)
       assert.equal(result.length, 2)
-      assert.hasAllKeys(result[0], ['asm', 'type', 'p2sh'])
+      assert.property(result[0], 'asm')
+      assert.property(result[0], 'type')
+      assert.property(result[0], 'p2sh')
     })
   })
 


### PR DESCRIPTION
This PR makes two significant changes to how bch-api retrieves transaction history for an address:

- Results are sorted in descending order (so most recent tx first).
- Only the last 100 txs are returned

Prior to this change, the default results from Fulcrum was returned, which ordered the transactions in ascending order (oldest first). It also returned the entire transaction history, which does not scale very well as some addresses can have a massive transaction history.

bch-js has [a tx sort function](https://bchjs.fullstack.cash/#api-ElectrumX-ElectrumX_sortAllTxs) if users want to sort transaction in ascending order. And an `allTxs` Boolean can be passed to retrieve the entire transaction history for addresses.