### PR TITLE
fix(electrumx): Updating library to use restURL from config file

### DIFF
--- a/src/routes/v5/electrumx.js
+++ b/src/routes/v5/electrumx.js
@@ -20,7 +20,7 @@ const RouteUtils = require('../../util/route-utils')
 const routeUtils = new RouteUtils()
 
 const BCHJS = require('@psf/bch-js')
-const bchjs = new BCHJS()
+const bchjs = new BCHJS({ restURL: config.restURL })
 
 let _this
 

--- a/src/routes/v5/electrumx.js
+++ b/src/routes/v5/electrumx.js
@@ -956,7 +956,7 @@ class Electrum {
           const thisEntry = response.data.transactions[i]
 
           if (thisEntry.transactions.length < 100) continue
-
+          console.log('thisEntry.transactions: ', thisEntry.transactions)
           // Extract only the first 100 transactions.
           thisEntry.transactions = thisEntry.transactions.slice(0, 100)
         }

--- a/test/v5/a01-electrumx.js
+++ b/test/v5/a01-electrumx.js
@@ -1344,6 +1344,7 @@ describe('#Electrumx', () => {
         sandbox.stub(electrumxRoute.axios, 'get').resolves({
           data: { success: true, transactions: mockData.transactions }
         })
+        sandbox.stub(electrumxRoute.bchjs.Electrumx, 'sortAllTxs').resolves(mockData.transactions)
       }
 
       // Call the details API.
@@ -1487,11 +1488,12 @@ describe('#Electrumx', () => {
         sandbox
           .stub(electrumxRoute.axios, 'post')
           .resolves({ data: mockData.transactionsBulk })
+        sandbox.stub(electrumxRoute.bchjs.Electrumx, 'sortAllTxs').resolves(mockData.transactionsBulk.transactions[0].transactions)
       }
 
       // Call the details API.
       const result = await electrumxRoute.transactionsBulk(req, res)
-      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+      console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.property(result, 'success')
       assert.equal(result.success, true)


### PR DESCRIPTION
This PR fixes a bug where instances of bch-api would reach out to api.fullstack.cash for Fulcrum indexer access, instead of accessing the local instance.