### PR TITLE
Add ElectrumX transaction merkle endpoints

### DIFF
--- a/src/routes/v5/electrumx.js
+++ b/src/routes/v5/electrumx.js
@@ -53,6 +53,8 @@ class Electrum {
     this.router.post('/utxos', this.utxosBulk)
     this.router.get('/tx/data/:txid', this.getTransactionDetails)
     this.router.post('/tx/data', this.transactionDetailsBulk)
+    this.router.get('/tx/merkle/:txid/:height', this.getTransactionMerkle)
+    this.router.post('/tx/merkle', this.transactionMerkleBulk)
     this.router.post('/tx/broadcast', this.broadcastTransaction)
     this.router.get('/block/headers/:height', this.getBlockHeaders)
     this.router.post('/block/headers', this.blockHeadersBulk)
@@ -564,6 +566,114 @@ class Electrum {
       return res.json(response.data)
     } catch (err) {
       wlogger.error('Error in electrumx.js/transactionDetailsBulk().', err)
+
+      return _this.errorHandler(err, res)
+    }
+  }
+
+  /**
+   * @api {get} /electrumx/tx/merkle/{txid}/{height} Get merkle branch for a TXID
+   * @apiName Merkle branch for a TXID
+   * @apiGroup ElectrumX / Fulcrum
+   * @apiDescription Returns the merkle branch for a transaction confirmed at the given block height.
+   *
+   * @apiExample Example usage:
+   * curl -X GET "https://api.fullstack.cash/v5/electrumx/tx/merkle/a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d/617812" -H "accept: application/json"
+   *
+   */
+  // GET handler for a single transaction merkle branch
+  async getTransactionMerkle (req, res, next) {
+    try {
+      const txid = req.params.txid
+      const height = Number(req.params.height)
+
+      // Reject if txid is anything other than a string
+      if (typeof txid !== 'string') {
+        res.status(400)
+        return res.json({
+          success: false,
+          error: 'txid must be a string'
+        })
+      }
+
+      // Reject if height is not a number
+      if (Number.isNaN(height) || height < 0) {
+        res.status(400)
+        return res.json({
+          success: false,
+          error: 'height must be a positive number'
+        })
+      }
+
+      wlogger.debug(
+        'Executing electrumx/getTransactionMerkle with this txid and height: ',
+        { txid, height }
+      )
+
+      // Get data from ElectrumX server.
+      const response = await _this.axios.get(
+        `${_this.fulcrumApi}electrumx/tx/merkle/${txid}/${height}`
+      )
+
+      res.status(200)
+      return res.json(response.data)
+    } catch (err) {
+      // Write out error to error log.
+      wlogger.error('Error in electrumx.js/getTransactionMerkle().', err)
+
+      return _this.errorHandler(err, res)
+    }
+  }
+
+  /**
+   * @api {post} /electrumx/tx/merkle Get merkle branches for an array of TXID + height pairs
+   * @apiName  Merkle branches for an array of TXID + height pairs
+   * @apiGroup ElectrumX / Fulcrum
+   * @apiDescription Returns an array of merkle branch results for an array of TXID + height pairs.
+   * Limited to 20 items per request.
+   *
+   * @apiExample Example usage:
+   * curl -X POST "https://api.fullstack.cash/v5/electrumx/tx/merkle" -H "accept: application/json" -H "Content-Type: application/json" -d '{"txids":[{ "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d", "height": 617812 }, { "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d", "height": 617812 }]}'
+   *
+   */
+  // POST handler for bulk queries on transaction merkle branches
+  async transactionMerkleBulk (req, res, next) {
+    try {
+      const txids = req.body.txids
+
+      // Reject if txids is not an array.
+      if (!Array.isArray(txids)) {
+        res.status(400)
+        return res.json({
+          success: false,
+          error: 'txids needs to be an array. Use GET for single txid.'
+        })
+      }
+
+      // Enforce array size rate limits
+      if (!_this.routeUtils.validateArraySize(req, txids)) {
+        res.status(400) // https://github.com/Bitcoin-com/rest.bitcoin.com/issues/330
+        return res.json({
+          success: false,
+          error: 'Array too large.'
+        })
+      }
+
+      wlogger.debug(
+        'Executing electrumx.js/transactionMerkleBulk with these txids: ',
+        txids
+      )
+
+      const response = await _this.axios.post(
+        `${_this.fulcrumApi}electrumx/tx/merkle`,
+        { txids }
+      )
+
+      // Return the array of retrieved transaction merkle branches.
+      res.status(200)
+      return res.json(response.data)
+    } catch (err) {
+      wlogger.error('Error in electrumx.js/transactionMerkleBulk().', err)
 
       return _this.errorHandler(err, res)
     }

--- a/test/v5/a01-electrumx.js
+++ b/test/v5/a01-electrumx.js
@@ -932,6 +932,234 @@ describe('#Electrumx', () => {
     })
   })
 
+  describe('#getTransactionMerkle', () => {
+    it('should throw 400 if tx is empty', async () => {
+      const result = await electrumxRoute.getTransactionMerkle(req, res)
+      // console.log(`result: ${util.inspect(result)}`)
+
+      assert.equal(res.statusCode, 400, 'Expect 400 status code')
+
+      assert.property(result, 'error')
+      assert.include(result.error, 'txid must be a string')
+
+      assert.property(result, 'success')
+      assert.equal(result.success, false)
+    })
+
+    it('should throw 400 on array input', async () => {
+      req.params.txid = [
+        'a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d'
+      ]
+      req.params.height = 617812
+
+      const result = await electrumxRoute.getTransactionMerkle(req, res)
+      // console.log(`result: ${util.inspect(result)}`)
+
+      assert.equal(res.statusCode, 400, 'Expect 400 status code')
+
+      assert.property(result, 'error')
+      assert.include(result.error, 'txid must be a string')
+
+      assert.property(result, 'success')
+      assert.equal(result.success, false)
+    })
+
+    it('should throw 400 if height is empty', async () => {
+      req.params.txid =
+        'a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d'
+
+      const result = await electrumxRoute.getTransactionMerkle(req, res)
+      // console.log(`result: ${util.inspect(result)}`)
+
+      assert.equal(res.statusCode, 400, 'Expect 400 status code')
+
+      assert.property(result, 'error')
+      assert.include(result.error, 'height must be a positive number')
+
+      assert.property(result, 'success')
+      assert.equal(result.success, false)
+    })
+
+    it('should throw 400 if height is not a number', async () => {
+      req.params.txid =
+        'a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d'
+      req.params.height = 'wrong type'
+
+      const result = await electrumxRoute.getTransactionMerkle(req, res)
+      // console.log(`result: ${util.inspect(result)}`)
+
+      assert.equal(res.statusCode, 400, 'Expect 400 status code')
+
+      assert.property(result, 'error')
+      assert.include(result.error, 'height must be a positive number')
+
+      assert.property(result, 'success')
+      assert.equal(result.success, false)
+    })
+
+    it('should pass errors from electrum-cash to user', async () => {
+      if (process.env.TEST === 'unit') {
+        sandbox.stub(electrumxRoute.axios, 'get').rejects({
+          response: {
+            data: {
+              error: {
+                message: {
+                  success: false,
+                  error: 'Invalid tx hash'
+                }
+              }
+            }
+          }
+        })
+      }
+
+      req.params.txid = '02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c'
+      req.params.height = 617812
+
+      const result = await electrumxRoute.getTransactionMerkle(req, res)
+      // console.log('result: ', result)
+
+      assert.property(result, 'error')
+      assert.include(result.error.error, 'Invalid tx hash')
+
+      assert.property(result, 'success')
+      assert.equal(result.success, false)
+    })
+
+    it('should get the merkle branch for a single tx', async () => {
+      req.params.txid =
+        'a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d'
+      req.params.height = 617812
+
+      // Mock unit tests to prevent live network calls.
+      if (process.env.TEST === 'unit') {
+        electrumxRoute.isReady = true // Force flag.
+
+        sandbox
+          .stub(electrumxRoute.axios, 'get')
+          .resolves({ data: { success: true, merkle: mockData.merkleBranch } })
+      }
+
+      // Call the merkle API.
+      const result = await electrumxRoute.getTransactionMerkle(req, res)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.property(result, 'success')
+      assert.equal(result.success, true)
+
+      assert.property(result, 'merkle')
+      assert.property(result.merkle, 'block_height')
+      assert.property(result.merkle, 'merkle')
+      assert.property(result.merkle, 'pos')
+      assert.isArray(result.merkle.merkle)
+    })
+  })
+
+  describe('#transactionMerkleBulk', () => {
+    it('should throw 400 if txids is empty', async () => {
+      const result = await electrumxRoute.transactionMerkleBulk(req, res)
+      // console.log(`result: ${util.inspect(result)}`)
+
+      assert.equal(res.statusCode, 400, 'Expect 400 status code')
+
+      assert.property(result, 'error')
+      assert.include(result.error, 'txids needs to be an array')
+
+      assert.property(result, 'success')
+      assert.equal(result.success, false)
+    })
+
+    it('should throw 400 if input provided is not array', async () => {
+      req.body.txids = {
+        txid: 'a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d',
+        height: 617812
+      }
+
+      const result = await electrumxRoute.transactionMerkleBulk(req, res)
+      // console.log(`result: ${util.inspect(result)}`)
+
+      assert.equal(res.statusCode, 400, 'Expect 400 status code')
+
+      assert.property(result, 'error')
+      assert.include(result.error, 'txids needs to be an array')
+
+      assert.property(result, 'success')
+      assert.equal(result.success, false)
+    })
+
+    it('should throw 400 error if txids array is too large', async () => {
+      const testArray = []
+      for (let i = 0; i < 25; i++) testArray.push('')
+
+      req.body.txids = testArray
+
+      const result = await electrumxRoute.transactionMerkleBulk(req, res)
+      // console.log(`result: ${util.inspect(result)}`)
+
+      assert.property(result, 'error')
+      assert.include(result.error, 'Array too large')
+
+      assert.property(result, 'success')
+      assert.equal(result.success, false)
+    })
+
+    it('should handle error', async () => {
+      req.body.txids = [
+        {
+          txid: 'a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d',
+          height: 617812
+        }
+      ]
+      // Force error
+      sandbox.stub(electrumxRoute.axios, 'post').throws(new Error('Test error'))
+
+      // Call the merkle API.
+      const result = await electrumxRoute.transactionMerkleBulk(req, res)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.property(result, 'success')
+      assert.equal(result.success, false)
+
+      assert.property(result, 'error')
+      assert.include(result.error, 'Test error')
+    })
+
+    it('should get merkle branches for an array of txids', async () => {
+      req.body.txids = [
+        {
+          txid: 'a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d',
+          height: 617812
+        }
+      ]
+
+      // Mock unit tests to prevent live network calls.
+      if (process.env.TEST === 'unit') {
+        electrumxRoute.isReady = true // Force flag.
+
+        sandbox
+          .stub(electrumxRoute.axios, 'post')
+          .resolves({ data: mockData.merkleBranchBulk })
+      }
+
+      // Call the merkle API.
+      const result = await electrumxRoute.transactionMerkleBulk(req, res)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.property(result, 'success')
+      assert.equal(result.success, true)
+
+      assert.property(result, 'branches')
+      const branch = result.branches[0]
+
+      assert.property(branch, 'txid')
+      assert.property(branch, 'height')
+      assert.property(branch, 'merkle')
+      assert.property(branch.merkle, 'block_height')
+      assert.property(branch.merkle, 'merkle')
+      assert.property(branch.merkle, 'pos')
+    })
+  })
+
   describe('#broadcastTransaction', () => {
     it('should throw 400 if txHex is empty', async () => {
       const result = await electrumxRoute.broadcastTransaction(req, res)

--- a/test/v5/integration/electrumx.js
+++ b/test/v5/integration/electrumx.js
@@ -107,4 +107,50 @@ describe('#electrumx', () => {
       assert.isAbove(firstElem.height, lastElem[0].height)
     })
   })
+
+  describe('#getTransactionMerkle', () => {
+    it('should get the merkle branch for a single tx', async () => {
+      req.params.txid =
+        'a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d'
+      req.params.height = 617812
+
+      const result = await uut.getTransactionMerkle(req, res)
+      // console.log('result: ', JSON.stringify(result, null, 2))
+
+      assert.property(result, 'success')
+      assert.equal(result.success, true)
+
+      assert.property(result, 'merkle')
+      assert.property(result.merkle, 'block_height')
+      assert.property(result.merkle, 'merkle')
+      assert.property(result.merkle, 'pos')
+      assert.isArray(result.merkle.merkle)
+    })
+  })
+
+  describe('#transactionMerkleBulk', () => {
+    it('should get merkle branches for an array of txids', async () => {
+      req.body.txids = [
+        {
+          txid: 'a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d',
+          height: 617812
+        }
+      ]
+
+      const result = await uut.transactionMerkleBulk(req, res)
+      // console.log('result: ', JSON.stringify(result, null, 2))
+
+      assert.property(result, 'success')
+      assert.equal(result.success, true)
+
+      assert.property(result, 'branches')
+      const branch = result.branches[0]
+      assert.property(branch, 'txid')
+      assert.property(branch, 'height')
+      assert.property(branch, 'merkle')
+      assert.property(branch.merkle, 'block_height')
+      assert.property(branch.merkle, 'merkle')
+      assert.property(branch.merkle, 'pos')
+    })
+  })
 })

--- a/test/v5/mocks/electrumx-mock.js
+++ b/test/v5/mocks/electrumx-mock.js
@@ -171,6 +171,31 @@ const txDetailsBulk = {
   transactions: [{ details: txDetails }]
 }
 
+const merkleBranch = {
+  block_height: 617812,
+  merkle: [
+    '713d6c7e6ce7bbea708d61162231eaa8ecb31c4c5dd84f81c20409a90069cb24',
+    '03dbaec78d4a52fbaf3c7aa5d3fccd9d8654f323940716ddf5ee2e4bda458fde'
+  ],
+  pos: 4
+}
+
+const merkleBranchBulk = {
+  success: true,
+  branches: [
+    {
+      txid: txDetails.txid,
+      height: 617812,
+      merkle: merkleBranch
+    },
+    {
+      txid: txDetails.txid,
+      height: 617812,
+      merkle: merkleBranch
+    }
+  ]
+}
+
 const blockHeaders = [
   '010000008b52bbd72c2f49569059f559c1b1794de5192e4f7d6d2b03c7482bad0000000083e4f8a9d502ed0c419075c1abb5d56f878a2e9079e5612bfb76a2dc37d9c42741dd6849ffff001d2b909dd6',
   '01000000f528fac1bcb685d0cd6c792320af0300a5ce15d687c7149548904e31000000004e8985a786d864f21e9cbb7cbdf4bc9265fe681b7a0893ac55a8e919ce035c2f85de6849ffff001d385ccb7c'
@@ -213,6 +238,8 @@ module.exports = {
   mempool,
   txDetails,
   txDetailsBulk,
+  merkleBranch,
+  merkleBranchBulk,
   blockHeaders,
   blockHeadersBulk,
   balances,


### PR DESCRIPTION
## Issue
Fixes Permissionless-Software-Foundation/bch-api#9.

## Summary
- adds GET /electrumx/tx/merkle/:txid/:height
- adds POST /electrumx/tx/merkle for bulk txid/height requests
- documents both endpoints with apidoc comments
- adds unit mocks, unit tests, and integration coverage for the new handlers

## Verification
- git diff --check
- node --check src/routes/v5/electrumx.js
- node --check test/v5/a01-electrumx.js
- node --check test/v5/integration/electrumx.js
- node .\node_modules\standard\bin\cmd.js --env mocha src\routes\v5\electrumx.js test\v5\a01-electrumx.js test\v5\integration\electrumx.js test\v5\mocks\electrumx-mock.js
- NETWORK=mainnet TEST=unit node .\node_modules\mocha\bin\mocha --exit --timeout 60000 --grep "(#getTransactionMerkle|#transactionMerkleBulk)" test\v5\a01-electrumx.js: 11 passing
- NETWORK=mainnet TEST=unit node .\node_modules\mocha\bin\mocha --exit --timeout 60000 test\v5\a01-electrumx.js: 98 passing

## Payout
PayPal: https://paypal.me/Jeremytsangchina
Backup USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y